### PR TITLE
Bluetooth: host: Update sdk-zephyr with Bluetooth qualification fixes

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -268,11 +268,7 @@ static void event_packet_process(u8_t *hci_buf)
 	}
 
 	net_buf_add_mem(evt_buf, &hci_buf[0], hdr->len + sizeof(*hdr));
-	if (bt_hci_evt_is_prio(hdr->evt)) {
-		bt_recv_prio(evt_buf);
-	} else {
-		bt_recv(evt_buf);
-	}
+	bt_recv(evt_buf);
 }
 
 static bool fetch_and_process_hci_evt(uint8_t *p_hci_buffer)

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.3.0-rc1-ncs1
+      revision: 274a3b6a75ccf8dfc41d1147d7501c57c7b338bc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr with Bluetooth qualification fixes for NCS 1.3-branch
Update HCI driver with new bt_recv priority handling, only calling
bt_recv since this is handled by hci_core now.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>